### PR TITLE
Clear Up AD list

### DIFF
--- a/ideas-list.md
+++ b/ideas-list.md
@@ -119,14 +119,18 @@ Stretch goals:
 - Familiarity with JuMP’s non-linear optimization interface
 - Familiarity with some of Julia’s Automatic Differentiation libraries
   including:
-  - [Cassette](https://github.com/jrevels/Cassette.jl)
-  - [ChainRules](https://github.com/JuliaDiff/ChainRules.jl)
-  - [Flux](https://github.com/FluxML)
+  
+  - [Flux](https://github.com/FluxML) / [Tracker](https://github.com/FluxML/Tracker.jl)
   - [Zygote](https://github.com/FluxML/Zygote.jl)
   - [ForwardDiff](https://github.com/JuliaDiff/ForwardDiff.jl)
-  - [ReverseDiff](https://github.com/JuliaDiff/ReverseDiff.jl)
   - [Nabla](https://github.com/invenia/Nabla.jl)
+  - [ReverseDiff](https://github.com/JuliaDiff/ReverseDiff.jl)
 
+  
+ Its is also useful to know about:
+  - [Cassette](https://github.com/jrevels/Cassette.jl)
+  - [ChainRules](https://github.com/JuliaDiff/ChainRules.jl)
+  
 #### First steps
 
 - Watch Miles's [JuliaCon talk](https://youtu.be/xtfNug-htcs) on JuMP's AD


### PR DESCRIPTION
I thought it was better to have 
ChainRules and Cassette mentioned seperately.
Since 
 - ChainRules isn't quiet AD, and isn't yet done
 - Cassette isn't AD, but is useful for AD

Also since Flux split Tracker to its own repo, should link to both.

I also dropped ReverseDiff to the bottom of the list as AIUI it is kind of dead?